### PR TITLE
Add string interpolation (and string concat operator)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -124,6 +124,7 @@ const OP2_LEFT_ASSOC = [
   "...",
   "..",
   "|>",
+  "<>",
 ];
 const OP2_RIGHT_ASSOC = ["=~", "++", "--"];
 

--- a/grammar.js
+++ b/grammar.js
@@ -161,11 +161,6 @@ const UNDERSCORE = "_";
 const STAR = "*";
 const TILDE = "~";
 
-// TODO: unicode support.
-const singleLineString = seq('"', repeat(/./), '"');
-
-// TODO: unicode support.
-const multiLineString = seq('"""', repeat(choice(/./, /\n/)), '"""');
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -261,7 +256,14 @@ module.exports = grammar({
       ),
     alias: ($) => seq(/[A-Z]/, repeat(/[0-9a-zA-Z_.]/)),
 
-    string: ($) => token(choice(singleLineString, multiLineString)),
+    // TODO: unicode string support
+    string: ($) => choice(
+      // single line string
+      seq('"', repeat(choice($.interpolation, /./)), '"'),
+      // multi line string
+      seq('"""', repeat(choice($.interpolation, choice(/./, /\n/))), '"""')),
+
+    interpolation: ($) => seq("#{", repeat($._expression), "}"),
 
     binary_string: ($) =>
       seq(BINARY_LEFT, optional(sepBy(COMMA, $.bin_part)), BINARY_RIGHT),

--- a/test/corpus/module_functions.txt
+++ b/test/corpus/module_functions.txt
@@ -57,7 +57,7 @@ Module function with guard clause
 ============
 
 def test(first_name, last_name) when is_nil(first_name) do
-  "#{first_name} #{last_name}"
+  "a simpler test"
 end
 
 ---

--- a/test/corpus/string.txt
+++ b/test/corpus/string.txt
@@ -21,3 +21,14 @@ Hello
 ---
 
 (source_file (string))
+
+===
+Concatenation
+===
+
+"left" <> "right"
+
+---
+
+(source_file
+  (expr_op (string) (string)))

--- a/test/corpus/string_interpolation.txt
+++ b/test/corpus/string_interpolation.txt
@@ -1,0 +1,52 @@
+======================
+basic
+======================
+"#{9999}"
+"#{var_name}"
+
+---
+
+(source_file
+  (string (interpolation (number)))
+  (string (interpolation (variable))))
+
+===
+with operator
+===
+
+"#{var_name + 9999}"
+
+---
+
+(source_file
+  (string (interpolation (expr_op (variable) (number)))))
+
+===
+with text
+===
+
+"x = #{x}, 2x = #{x * 2}"
+
+---
+
+(source_file
+  (string
+    (interpolation (variable))
+    (interpolation (expr_op (variable) (number)))))
+
+===
+in mutil line strings
+===
+
+"""
+This muilti line string,
+includes #{interpolation} with some #{oper * ations}
+
+Neat."""
+
+---
+
+(source_file
+  (string
+    (interpolation (variable))
+    (interpolation (expr_op (variable) (variable)))))

--- a/test/corpus/string_interpolation.txt
+++ b/test/corpus/string_interpolation.txt
@@ -50,3 +50,27 @@ Neat."""
   (string
     (interpolation (variable))
     (interpolation (expr_op (variable) (variable)))))
+
+===
+interpolating strings in strings
+===
+
+"This string #{"contains a string"}"
+
+---
+
+(source_file
+  (string
+    (interpolation (string))))
+
+===
+interpolating strings in strings with operator
+===
+
+"This string #{"contains" <> "operation"}"
+
+---
+
+(source_file
+  (string
+    (interpolation (expr_op (string) (string)))))


### PR DESCRIPTION
Adds support for interpolation in strings.

I had to move the `singleLineString`/`multiLineString`  "macros" down into the rules so they had access to `$`. They were only used once, in the rules, so I think this is ok.

I also added support for the `<>` operator which was missing.