### PR TITLE
Add interpolation test in comments test

### DIFF
--- a/test/todo/comment.txt
+++ b/test/todo/comment.txt
@@ -67,3 +67,16 @@ Comment in nested structure
       (number)
       (comment)
       (number))))
+ 
+ ====
+ Doesn't match inside string
+ ====
+ 
+ # this is a comment
+ "this is #{interpolation}"
+ 
+  -----
+  
+  (source_file
+    (comment)
+    (string (interpolation (variable)))


### PR DESCRIPTION
I was just syncing up my fork and thought the comment test should ensure that `#` aren't matched incorrectly in strings.

I haven't looked at implementation yet, maybe there isn't much risk of mis-matching. It did stick out as a potential sharp edge though.